### PR TITLE
Fix of template execution, added template remLineBreaks function, append project on view

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -16,20 +16,20 @@ import (
 
 type IssueQueryProvider interface {
 	ProvideIssueQueryString() string
-    ProvideDefaultProject() string
+	ProvideDefaultProject() string
 }
 
 type IssueOptions struct {
-	Fields        []string `json:"fields,omitempty" yaml:"fields,omitempty"`
-	Expand        []string `json:"expand,omitempty" yaml:"expand,omitempty"`
-	Properties    []string `json:"properties,omitempty" yaml:"properties,omitempty"`
-	FieldsByKeys  bool     `json:"fieldsByKeys,omitempty" yaml:"fieldsByKeys,omitempty"`
-	UpdateHistory bool     `json:"updateHistory,omitempty" yaml:"updateHistory,omitempty"`
-    Project       string `json:"project,omitempty" yaml:"project,omitempty"`
+	Fields	    []string `json:"fields,omitempty" yaml:"fields,omitempty"`
+	Expand	    []string `json:"expand,omitempty" yaml:"expand,omitempty"`
+	Properties	[]string `json:"properties,omitempty" yaml:"properties,omitempty"`
+	FieldsByKeys  bool	 `json:"fieldsByKeys,omitempty" yaml:"fieldsByKeys,omitempty"`
+	UpdateHistory bool	 `json:"updateHistory,omitempty" yaml:"updateHistory,omitempty"`
+	Project	      string `json:"project,omitempty" yaml:"project,omitempty"`
 }
 
 func (o *IssueOptions) ProvideDefaultProject() string {
-    return o.Project
+	return o.Project
 }
 
 func (o *IssueOptions) ProvideIssueQueryString() string {
@@ -56,8 +56,8 @@ func (o *IssueOptions) ProvideIssueQueryString() string {
 }
 
 func CaseInsensitiveContains(s, substr string) bool {
-    s, substr = strings.ToUpper(s), strings.ToUpper(substr)
-    return strings.Contains(s, substr)
+	s, substr = strings.ToUpper(s), strings.ToUpper(substr)
+	return strings.Contains(s, substr)
 }
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-getIssue
@@ -67,7 +67,7 @@ func (j *Jira) GetIssue(issue string, iqg IssueQueryProvider) (*jiradata.Issue, 
 
 func GetIssue(ua HttpClient, endpoint string, issue string, iqg IssueQueryProvider) (*jiradata.Issue, error) {
 	query := ""
-    pro := iqg.ProvideDefaultProject()
+	pro := iqg.ProvideDefaultProject()
 	if iqg != nil {
 		query = iqg.ProvideIssueQueryString()
 	}
@@ -83,11 +83,11 @@ func GetIssue(ua HttpClient, endpoint string, issue string, iqg IssueQueryProvid
 		results := &jiradata.Issue{}
 		return results, readJSON(resp.Body, results)
 	}
-    // Ticket not found, maybe try prepend Project value?
-    if ! CaseInsensitiveContains(issue,pro) {
-        issue = pro+"-"+issue
-        return GetIssue(ua, endpoint, issue, iqg)
-    }
+	// Ticket not found, maybe try prepend Project value?
+	if ! CaseInsensitiveContains(issue,pro) {
+		issue = pro+"-"+issue
+		return GetIssue(ua, endpoint, issue, iqg)
+	}
 	return nil, responseError(resp)
 }
 

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -143,6 +143,9 @@ func TemplateProcessor() *template.Template {
 		"color": func(color string) string {
 			return ansi.ColorCode(color)
 		},
+		"remLineBreak": func(content string) string {
+			return strings.Replace(strings.Replace(content,string('\r'),string(' '),-1),string('\n'),string(' '),-1)
+		},
 		"regReplace": func(search string, replace string, content string) string {
 			re := regexp.MustCompile(search)
 			return re.ReplaceAllString(content, replace)

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -34,8 +34,8 @@ func findTemplate(name string) ([]byte, error) {
 }
 
 func getTemplate(name string) (string, error) {
-	if _, err := os.Stat(name); err == nil {
-		b, err := ioutil.ReadFile(name)
+	if _, err := os.Stat(".jira.d/"+name); err == nil {
+		b, err := ioutil.ReadFile(".jira.d/"+name)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
I would like to see eventually [gojira template] as the first line of templates or similar so we have an even more direct way of filter what is and whats not a template.

This fixes it for me at least. I pushed the first readfile to ```.jira.d/templatename```.  It was still able to execute the file mistaken as a template if in the .jira.d folder but at least it wont do it if a file matches in the ```pwd```.