### PR TITLE
Migrate from gopkg.in to github.com, to support 'go mod' more cleanly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: go
 
 go:
   - 1.12.x
+  - 1.13.x
 
 env:
   - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/Netflix-Skunkworks/go-jira.svg?branch=master)](https://travis-ci.org/Netflix-Skunkworks/go-jira)
-[![GoDoc](https://godoc.org/gopkg.in/Netflix-Skunkworks/go-jira.v1?status.svg)](https://godoc.org/gopkg.in/Netflix-Skunkworks/go-jira.v1)
+[![Build Status](https://travis-ci.org/go-jira/jira/go-jira.svg?branch=master)](https://travis-ci.org/go-jira/jira)
+[![GoDoc](https://godoc.org/github.com/go-jira/jira?status.svg)](https://godoc.org/github.com/go-jira/jira)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # go-jira
@@ -10,15 +10,17 @@ Simple command line client for Atlassian's Jira service written in Go.
 
 ### Download
 
-You can download one of the pre-built binaries for **go-jira** [here](https://github.com/Netflix-Skunkworks/go-jira/releases).
+You can download one of the pre-built binaries for **go-jira** [here](https://github.com/go-jira/jira/releases).
 
 ### Build
 
 You can build and install the official repository with [Go](https://golang.org/dl/):
 
-	go get gopkg.in/Netflix-Skunkworks/go-jira.v1/cmd/jira
+	go get github.com/go-jira/jira/cmd/jira
 
-This will checkout this repository into `$GOPATH/src/gopkg.in/Netflix-Skunkworks/go-jira.v1`, build, and install it.
+This will checkout this repository into `$GOPATH/src/github.com/go-jira/jira/`, build, and install it.
+
+It should then be available in $GOPATH/bin/jira
 
 ## Usage
 
@@ -258,7 +260,7 @@ hard-coded templates with `jira export-templates` which will write them to **~/.
 
 #### Writing/Editing Templates
 
-First the basic templating functionality is defined by the Go language 'text/template' library.  The library reference documentation can be found [here](https://golang.org/pkg/text/template/), and there is a good primer document [here](https://gohugo.io/templates/go-templates/).  `go-jira` also provides a few extra helper functions to make it a bit easier to format the data, those functions are defined [here](https://github.com/Netflix-Skunkworks/go-jira/blob/master/jiracli/templates.go#L64).
+First the basic templating functionality is defined by the Go language 'text/template' library.  The library reference documentation can be found [here](https://golang.org/pkg/text/template/), and there is a good primer document [here](https://gohugo.io/templates/go-templates/).  `go-jira` also provides a few extra helper functions to make it a bit easier to format the data, those functions are defined [here](https://github.com/go-jira/jira/blob/master/jiracli/templates.go#L64).
 
 Knowing what data and fields are available to any given template is not obvious. The easiest approach to determine what is available is to use the `debug` template on any given operation.  For example to find out what is available to the "view" templates, you can use:
 ```

--- a/attachment.go
+++ b/attachment.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"encoding/json"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/attachment-getAttachment

--- a/cmd/jira/main.go
+++ b/cmd/jira/main.go
@@ -7,8 +7,8 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracmd"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiracmd"
 	"gopkg.in/op/go-logging.v1"
 )
 

--- a/component.go
+++ b/component.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 type ComponentProvider interface {

--- a/epic.go
+++ b/epic.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 // https://docs.atlassian.com/jira-software/REST/latest/#agile/1.0/epic-getIssuesForEpic

--- a/error.go
+++ b/error.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 func responseError(resp *http.Response) error {

--- a/fields.go
+++ b/fields.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"encoding/json"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/field-getFields

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/Netflix-Skunkworks/go-jira.v1
+module github.com/go-jira/jira
 
 go 1.12
 

--- a/issue.go
+++ b/issue.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 type IssueQueryProvider interface {

--- a/jiracli/password.go
+++ b/jiracli/password.go
@@ -8,8 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/go-jira/jira/jiradata"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
 )
 
 func (o *GlobalOptions) ProvideAuthParams() *jiradata.AuthParams {

--- a/jiracli/usage.go
+++ b/jiracli/usage.go
@@ -11,7 +11,7 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/kingpeon"
 	"github.com/coryb/oreo"
-	jira "gopkg.in/Netflix-Skunkworks/go-jira.v1"
+	jira "github.com/go-jira/jira"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/assign.go
+++ b/jiracmd/assign.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/attachCreate.go
+++ b/jiracmd/attachCreate.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	jira "gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	jira "github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	yaml "gopkg.in/coryb/yaml.v2"
 )

--- a/jiracmd/attachGet.go
+++ b/jiracmd/attachGet.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	jira "gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	jira "github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/attachList.go
+++ b/jiracmd/attachList.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/attachRemove.go
+++ b/jiracmd/attachRemove.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	jira "gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	jira "github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/block.go
+++ b/jiracmd/block.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/browse.go
+++ b/jiracmd/browse.go
@@ -3,9 +3,9 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
+	jira "github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	"github.com/pkg/browser"
-	jira "gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/comment.go
+++ b/jiracmd/comment.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/componentAdd.go
+++ b/jiracmd/componentAdd.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/components.go
+++ b/jiracmd/components.go
@@ -6,8 +6,8 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/create.go
+++ b/jiracmd/create.go
@@ -7,9 +7,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	yaml "gopkg.in/coryb/yaml.v2"
 )

--- a/jiracmd/createmeta.go
+++ b/jiracmd/createmeta.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/dup.go
+++ b/jiracmd/dup.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/edit.go
+++ b/jiracmd/edit.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	"gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/editmeta.go
+++ b/jiracmd/editmeta.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/epicAdd.go
+++ b/jiracmd/epicAdd.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/epicCreate.go
+++ b/jiracmd/epicCreate.go
@@ -4,7 +4,7 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/epicList.go
+++ b/jiracmd/epicList.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/epicRemove.go
+++ b/jiracmd/epicRemove.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/exportTemplates.go
+++ b/jiracmd/exportTemplates.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/fields.go
+++ b/jiracmd/fields.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/issuelink.go
+++ b/jiracmd/issuelink.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/issuelinktypes.go
+++ b/jiracmd/issuelinktypes.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/issuetypes.go
+++ b/jiracmd/issuetypes.go
@@ -6,8 +6,8 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/labelsAdd.go
+++ b/jiracmd/labelsAdd.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/labelsRemove.go
+++ b/jiracmd/labelsRemove.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/labelsSet.go
+++ b/jiracmd/labelsSet.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/list.go
+++ b/jiracmd/list.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/login.go
+++ b/jiracmd/login.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	"github.com/mgutz/ansi"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/logout.go
+++ b/jiracmd/logout.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	"github.com/mgutz/ansi"
 	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/rank.go
+++ b/jiracmd/rank.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/registry.go
+++ b/jiracmd/registry.go
@@ -1,6 +1,6 @@
 package jiracmd
 
-import "gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+import "github.com/go-jira/jira/jiracli"
 
 func RegisterAllCommands() {
 	jiracli.RegisterCommand(jiracli.CommandRegistry{Command: "acknowledge", Entry: CmdTransitionRegistry("acknowledge"), Aliases: []string{"ack"}})

--- a/jiracmd/request.go
+++ b/jiracmd/request.go
@@ -9,7 +9,7 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/session.go
+++ b/jiracmd/session.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	yaml "gopkg.in/coryb/yaml.v2"
 )

--- a/jiracmd/subtask.go
+++ b/jiracmd/subtask.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/take.go
+++ b/jiracmd/take.go
@@ -3,7 +3,7 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/transition.go
+++ b/jiracmd/transition.go
@@ -7,9 +7,9 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/transitions.go
+++ b/jiracmd/transitions.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/unassign.go
+++ b/jiracmd/unassign.go
@@ -3,7 +3,7 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/unexportTemplates.go
+++ b/jiracmd/unexportTemplates.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/view.go
+++ b/jiracmd/view.go
@@ -3,8 +3,8 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/vote.go
+++ b/jiracmd/vote.go
@@ -6,8 +6,8 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/watch.go
+++ b/jiracmd/watch.go
@@ -6,8 +6,8 @@ import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/worklogAdd.go
+++ b/jiracmd/worklogAdd.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jiracmd/worklogList.go
+++ b/jiracmd/worklogList.go
@@ -3,9 +3,9 @@ package jiracmd
 import (
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiracli"
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira"
+	"github.com/go-jira/jira/jiracli"
+	"github.com/go-jira/jira/jiradata"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/project.go
+++ b/project.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"encoding/json"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/project-getProjectComponents

--- a/search.go
+++ b/search.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 type SearchProvider interface {

--- a/session.go
+++ b/session.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"gopkg.in/Netflix-Skunkworks/go-jira.v1/jiradata"
+	"github.com/go-jira/jira/jiradata"
 )
 
 type AuthProvider interface {


### PR DESCRIPTION
I'm not 100% on this PR, so would really like a second pair of eyes from someone who's used to using modules.

This PR removes reference to the old repository and in particular the use of gopkg.in as an import source - it appears to have been preventing go module support from being useful for pinning against a non-released SHA or branch. Essentially, since gopkg.in only pulls vX.Y.Z tagged releases from github, there's nothing there to pull from if you want to use the 'go get {repo}@{git-sha} syntax.

In the process of this, I noticed that #228 was still a problem, despite the move to using '_t' as the prefix for the cli tests. I implemented a temp-file fix to address the problem, so it should now work - at least the tests pass.

