### PR TITLE
Add support to switch out password source binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,3 +374,19 @@ When `password-source` is set to `stdin`, the `jira login` command will read fro
 ```bash
 $ ./password-generator | jira login --endpoint=https://my.jira.endpoint.com --user=USERNAME
 ```
+
+#### Switch binary used for password source
+For `gopass` and `pass` it is possible to switch the binary used for retrieval of the password. This can be accomplised
+by setting the `password-source-binary` option in the configuration file. 
+
+E.g.
+```yaml
+password-source: gopass
+password-name: jira.example.com/myuser
+password-source-binary: my-special-gopass
+```
+
+This will cause go-jira to use the `gopass` style cli interaction with the `my-special-gopass` binary.
+
+If you ommit the `password-source-binary` option, either `gopass` (for `gopass`) or `pass` (for `pass`) 
+will be used.

--- a/jiracli/cli.go
+++ b/jiracli/cli.go
@@ -71,6 +71,8 @@ type GlobalOptions struct {
 	// location using the `pass` tool, if missing prompt the user and store in the PasswordDirectory
 	PasswordSource figtree.StringOption `yaml:"password-source,omitempty" json:"password-source,omitempty"`
 
+	PasswordSourceBinary figtree.StringOption `yaml:"password-source-binary,omitempty" json:"password-source-binary,omitempty"`
+
 	// PasswordDirectory is only used for the "pass" PasswordSource.  It is the location for the encrypted password
 	// files used by `pass`.  Effectively this overrides the "PASSWORD_STORE_DIR" environment variable
 	PasswordDirectory figtree.StringOption `yaml:"password-directory,omitempty" json:"password-directory,omitempty"`

--- a/jiracli/password.go
+++ b/jiracli/password.go
@@ -41,6 +41,20 @@ func (o *GlobalOptions) keyName() string {
 	return user
 }
 
+func (o *GlobalOptions) GetPasswordBinary() string {
+        binary := o.PasswordSourceBinary.Value
+
+        if binary == "" {
+          if o.PasswordSource.Value == "gopass" {
+            return "gopass"
+          } else if o.PasswordSource.Value == "pass" {
+            return "pass"
+          }
+        }
+
+        return binary 
+}
+
 func (o *GlobalOptions) GetPass() string {
 	passwd := ""
 	if o.PasswordSource.Value != "" {
@@ -50,13 +64,15 @@ func (o *GlobalOptions) GetPass() string {
 			if err != nil {
 				panic(err)
 			}
-		} else if o.PasswordSource.Value == "gopass" {
+		} else if o.PasswordSource.Value == "gopass" && o.GetPasswordBinary() != "" {
+                        binary := o.GetPasswordBinary()
+
 			if o.PasswordDirectory.Value != "" {
 				orig := os.Getenv("PASSWORD_STORE_DIR")
 				os.Setenv("PASSWORD_STORE_DIR", o.PasswordDirectory.Value)
 				defer os.Setenv("PASSWORD_STORE_DIR", orig)
 			}
-			if bin, err := exec.LookPath("gopass"); err == nil {
+			if bin, err := exec.LookPath(binary); err == nil {
 				buf := bytes.NewBufferString("")
 				cmd := exec.Command(bin, "show", "-o", o.keyName())
 				cmd.Stdout = buf
@@ -69,13 +85,14 @@ func (o *GlobalOptions) GetPass() string {
 			} else {
 				log.Warning("Gopass binary was not found! Fallback to default password behaviour!")
 			}
-		} else if o.PasswordSource.Value == "pass" {
+		} else if o.PasswordSource.Value == "pass" && o.GetPasswordBinary() != "" {
+                        binary := o.GetPasswordBinary()
 			if o.PasswordDirectory.Value != "" {
 				orig := os.Getenv("PASSWORD_STORE_DIR")
 				os.Setenv("PASSWORD_STORE_DIR", o.PasswordDirectory.Value)
 				defer os.Setenv("PASSWORD_STORE_DIR", orig)
 			}
-			if bin, err := exec.LookPath("pass"); err == nil {
+			if bin, err := exec.LookPath(binary); err == nil {
 				buf := bytes.NewBufferString("")
 				cmd := exec.Command(bin, o.keyName())
 				cmd.Stdout = buf


### PR DESCRIPTION
Add support to switch out password source binary

    There is now a new configuration entry option `password-source-binary`,
    which allows to use an alternate binary for the gopass/pass password
    source.

    If the option is not specified, we will fallback to `pass` (for `pass`)
    and `gopass` (for `gopass`).

This fixes #288 