### PR TITLE
Cache password to avoid invoking password source on each API request with api-token

### DIFF
--- a/jiracli/cli.go
+++ b/jiracli/cli.go
@@ -71,6 +71,9 @@ type GlobalOptions struct {
 	// location using the `pass` tool, if missing prompt the user and store in the PasswordDirectory
 	PasswordSource figtree.StringOption `yaml:"password-source,omitempty" json:"password-source,omitempty"`
 
+	// Cached password to avoid invoking password source on each API request
+	cachedPassword string
+
 	// PasswordDirectory is only used for the "pass" PasswordSource.  It is the location for the encrypted password
 	// files used by `pass`.  Effectively this overrides the "PASSWORD_STORE_DIR" environment variable
 	PasswordDirectory figtree.StringOption `yaml:"password-directory,omitempty" json:"password-directory,omitempty"`


### PR DESCRIPTION
This PR reduces the number of times a password source is invoked to retrieve the api-token during a single run of jira from one for each API request to a single one on the first API request.

This is particularly noticeable when using gopass as a password source with a yubikey whose LED flashes when it is solicited to decrypt the password.

An alternative option I considered was to modify [the oreo pre-callback were `globals.GetPass()` is invoked](https://github.com/go-jira/jira/blob/v1.0.22/jiracli/cli.go#L156) but it required much more changes because at the time it is run, the configuration is not yet loaded and the defaulting on `api-token` for atlassian.net endpoints not evaluated.
