### PR TITLE
Use `stty` when available to set tty width for tests

### DIFF
--- a/_t/env.sh
+++ b/_t/env.sh
@@ -1,4 +1,8 @@
 export COLUMNS=149
+if command -v stty 1>/dev/null 2>/dev/null
+then
+  stty columns 149
+fi
 export JIRA_LOG_FORMAT="%{level:-5s} %{message}"
 export ENDPOINT="https://go-jira.atlassian.net"
 export GNUPGHOME=$(pwd)/.gnupg


### PR DESCRIPTION
Checks for `stty` in path and uses it, if available, to set terminal
width (`stty columns 149`). This guarantees that the desired terminal
width is used for tests when the value comes from `ioctl`, since [that
has priority over the `COLUMNS` env var](https://github.com/go-jira/jira/blob/590244947b92c5cfef5dc61b4e1aa931f8da5762/jiracli/templates.go#L101).

This addresses an issue where tests for the output of templates that
use the `termWidth` template function would fail when run in certain
environments - in my case, `bash` running in `rxvt-unicode-256color`
in Fedora 30 - when the terminal width doesn't match `149` like the
test expects.