### PR TITLE
Adding the option --file to the create jira command

### DIFF
--- a/jiracmd/create.go
+++ b/jiracmd/create.go
@@ -46,6 +46,7 @@ func CmdCreateRegistry() *jiracli.CommandRegistryEntry {
 func CmdCreateUsage(cmd *kingpin.CmdClause, opts *CreateOptions) error {
 	jiracli.BrowseUsage(cmd, &opts.CommonOptions)
 	jiracli.EditorUsage(cmd, &opts.CommonOptions)
+	jiracli.FileUsage(cmd, &opts.CommonOptions)
 	jiracli.TemplateUsage(cmd, &opts.CommonOptions)
 	cmd.Flag("noedit", "Disable opening the editor").SetValue(&opts.SkipEditing)
 	cmd.Flag("project", "project to create issue in").Short('p').StringVar(&opts.Project)
@@ -85,10 +86,19 @@ func CmdCreate(o *oreo.Client, globals *jiracli.GlobalOptions, opts *CreateOptio
 	input.Overrides["user"] = globals.User.Value
 
 	var issueResp *jiradata.IssueCreateResponse
-	err = jiracli.EditLoop(&opts.CommonOptions, &input, &issueUpdate, func() error {
-		issueResp, err = jira.CreateIssue(o, globals.Endpoint.Value, &issueUpdate)
-		return err
-	})
+    var fnameOptsFile string
+    fnameOptsFile = opts.File.String()
+    if fnameOptsFile != "" {
+        err = jiracli.ReadYmlInputFile(&opts.CommonOptions, &input, &issueUpdate, func() error {
+            issueResp, err = jira.CreateIssue(o, globals.Endpoint.Value, &issueUpdate)
+            return err
+        })
+    } else {
+        err = jiracli.EditLoop(&opts.CommonOptions, &input, &issueUpdate, func() error {
+            issueResp, err = jira.CreateIssue(o, globals.Endpoint.Value, &issueUpdate)
+            return err
+        })
+    }
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This to allow users to run the jira create command without using the editor. Hence without user interaction. This method of using a file, is more conventional. The input file is strictly a replacement of the editor content. 
I know that it is possible to use the editor with noedit, in combination with the override  options to achieve similar results, and to populate individual fields. But unfortunately, I found that this solution doesn't work in all situations.
example of use:
jira.exe create --file="create_LHR.yml" --project="LHR"
