### PR TITLE
Use accountId parameter for GDPR compliant API requests

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -439,13 +439,13 @@ func RankIssues(ua HttpClient, endpoint string, rrp RankRequestProvider) error {
 }
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-addWatcher
-func (j *Jira) IssueAddWatcher(issue, user string) error {
-	return IssueAddWatcher(j.UA, j.Endpoint, issue, user)
+func (j *Jira) IssueAddWatcher(issue, accountId string) error {
+	return IssueAddWatcher(j.UA, j.Endpoint, issue, accountId)
 }
 
-func IssueAddWatcher(ua HttpClient, endpoint string, issue, user string) error {
+func IssueAddWatcher(ua HttpClient, endpoint string, issue, accountId string) error {
 	uri := URLJoin(endpoint, "rest/api/2/issue", issue, "watchers")
-	resp, err := ua.Post(uri, "application/json", strings.NewReader(fmt.Sprintf("%q", user)))
+	resp, err := ua.Post(uri, "application/json", strings.NewReader(fmt.Sprintf("%q", accountId)))
 	if err != nil {
 		return err
 	}
@@ -458,13 +458,13 @@ func IssueAddWatcher(ua HttpClient, endpoint string, issue, user string) error {
 }
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-addWatcher
-func (j *Jira) IssueRemoveWatcher(issue, user string) error {
-	return IssueRemoveWatcher(j.UA, j.Endpoint, issue, user)
+func (j *Jira) IssueRemoveWatcher(issue, accountId string) error {
+	return IssueRemoveWatcher(j.UA, j.Endpoint, issue, accountId)
 }
 
-func IssueRemoveWatcher(ua HttpClient, endpoint string, issue, user string) error {
+func IssueRemoveWatcher(ua HttpClient, endpoint string, issue, accountId string) error {
 	uri := URLJoin(endpoint, "rest/api/2/issue", issue, "watchers")
-	uri += fmt.Sprintf("?username=%s", user)
+	uri += fmt.Sprintf("?accountId=%s", accountId)
 	resp, err := ua.Delete(uri)
 	if err != nil {
 		return err
@@ -511,19 +511,19 @@ type UserProvider interface {
 }
 
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-assign
-func (j *Jira) IssueAssign(issue, name string) error {
-	return IssueAssign(j.UA, j.Endpoint, issue, name)
+func (j *Jira) IssueAssign(issue, accountId string) error {
+	return IssueAssign(j.UA, j.Endpoint, issue, accountId)
 }
 
-func IssueAssign(ua HttpClient, endpoint string, issue, name string) error {
+func IssueAssign(ua HttpClient, endpoint string, issue, accountId string) error {
 	// this is special, not using the jiradata.User structure
 	// because we need to be able to send `null` as the name param
 	// when we want to un-assign the issue
 	req := struct {
-		Name *string `json:"name"`
-	}{&name}
-	if name == "" {
-		req.Name = nil
+		AccountId *string `json:"accountId"`
+	}{&accountId}
+	if accountId == "" {
+		req.AccountId = nil
 	}
 
 	encoded, err := json.Marshal(req)

--- a/jiracli/cli.go
+++ b/jiracli/cli.go
@@ -102,6 +102,10 @@ type GlobalOptions struct {
 	// `username`  The User property is used on Jira service API calls that require a user to associate with
 	// an Issue (like assigning a Issue to yourself)
 	User figtree.StringOption `yaml:"user,omitempty" json:"user,omitempty"`
+
+	// AccountId is used to represent the user on the Jira service.  The AccountId property is used on Jira
+	// service API calls that require a user to associate with an Issue (like assigning a Issue to yourself)
+	AccountId figtree.StringOption `yaml:"account-id,omitempty" json:"accountId,omitempty"`
 }
 
 type CommonOptions struct {
@@ -156,6 +160,7 @@ func register(app *kingpin.Application, o *oreo.Client, fig *figtree.FigTree) {
 	app.Flag("socksproxy", "Address for a socks proxy").SetValue(&globals.SocksProxy)
 	app.Flag("user", "user name used within the Jira service").Short('u').SetValue(&globals.User)
 	app.Flag("login", "login name that corresponds to the user used for authentication").SetValue(&globals.Login)
+	app.Flag("account-id", "account id that corresponds to the user used within the Jira service").SetValue(&globals.AccountId)
 
 	o = o.WithPreCallback(func(req *http.Request) (*http.Request, error) {
 		if globals.AuthMethod() == "api-token" {

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -357,7 +357,7 @@ const defaultAttachListTemplate = `{{/* attach list template */ -}}
   {{- cell .id -}}
   {{- cell .filename -}}
   {{- cell .size -}}
-  {{- cell .author.name -}}
+  {{- cell .author.displayName -}}
   {{- cell (.created | age) -}}
 {{- end -}}
 `
@@ -402,7 +402,7 @@ description: |
   {{ or .fields.description "" | indent 2 }}
 {{if .fields.comment.comments}}
 comments:
-{{ range .fields.comment.comments }}  - | # {{.author.name}}, {{.created | age}} ago
+{{ range .fields.comment.comments }}  - | # {{.author.displayName}}, {{.created | age}} ago
     {{ or .body "" | indent 4}}
 {{end}}
 {{end -}}
@@ -439,7 +439,7 @@ fields:
     {{ or .overrides.description .fields.description "" | indent 4 }}
 # votes: {{ .fields.votes.votes }}
 # comments:
-# {{ range .fields.comment.comments }}  - | # {{.author.name}}, {{.created | age}} ago
+# {{ range .fields.comment.comments }}  - | # {{.author.displayName}}, {{.created | age}} ago
 #     {{ or .body "" | indent 4 | comment}}
 # {{end}}
 `
@@ -610,7 +610,7 @@ started: {{ or .started "" }}
 `
 
 const defaultWorklogsTemplate = `{{/* worklogs template */ -}}
-{{ range .worklogs }}- # {{.author.name}}, {{.created | age}} ago
+{{ range .worklogs }}- # {{.author.displayName}}, {{.created | age}} ago
   comment: {{ or .comment "" }}
   started: {{ .started }}
   timeSpent: {{ .timeSpent }}

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -338,12 +338,12 @@ const defaultTableTemplate = `{{/* table template */ -}}
   {{- cell .fields.status.name -}}
   {{- cell (.fields.created | age) -}}
   {{- if .fields.reporter -}}
-    {{- cell .fields.reporter.name -}}
+    {{- cell .fields.reporter.displayName -}}
   {{- else -}}
     {{- cell "<unknown>" -}}
   {{- end -}}
   {{- if .fields.assignee -}}
-    {{- cell .fields.assignee.name -}}
+    {{- cell .fields.assignee.displayName -}}
   {{- else -}}
     {{- cell "<unassigned>" -}}
   {{- end -}}
@@ -379,9 +379,9 @@ components: {{ range .fields.components }}{{ .name }} {{end}}
 issuetype: {{ .fields.issuetype.name }}
 {{end -}}
 {{if .fields.assignee -}}
-assignee: {{ .fields.assignee.name }}
+assignee: {{ .fields.assignee.displayName }}
 {{end -}}
-reporter: {{ if .fields.reporter }}{{ .fields.reporter.name }}{{end}}
+reporter: {{ if .fields.reporter }}{{ .fields.reporter.displayName }}{{end}}
 {{if .fields.customfield_10110 -}}
 watchers: {{ range .fields.customfield_10110 }}{{ .name }} {{end}}
 {{end -}}
@@ -423,10 +423,10 @@ fields:
     - name: {{ .name }}{{end}}{{end}}{{end}}
 {{- if .meta.fields.assignee}}
   assignee:
-    name: {{ if .overrides.assignee }}{{.overrides.assignee}}{{else}}{{if .fields.assignee }}{{ .fields.assignee.name }}{{end}}{{end}}{{end}}
+    name: {{ if .overrides.assignee }}{{.overrides.assignee}}{{else}}{{if .fields.assignee }}{{ .fields.assignee.displayName }}{{end}}{{end}}{{end}}
 {{- if .meta.fields.reporter}}
   reporter:
-    name: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.name }}{{end}}{{end}}
+    name: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.displayName }}{{end}}{{end}}
 {{- if .meta.fields.customfield_10110}}
   # watchers
   customfield_10110: {{ range .fields.customfield_10110 }}
@@ -548,7 +548,7 @@ update:
 fields:
 {{- if .meta.fields.assignee}}
   assignee:
-    name: {{if .overrides.assignee}}{{.overrides.assignee}}{{else}}{{if .fields.assignee}}{{.fields.assignee.name}}{{end}}{{end}}
+    name: {{if .overrides.assignee}}{{.overrides.assignee}}{{else}}{{if .fields.assignee}}{{.fields.assignee.displayName}}{{end}}{{end}}
 {{- end -}}
 {{if .meta.fields.components}}
   components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{if .overrides.components }}{{ range (split "," .overrides.components)}}
@@ -581,7 +581,7 @@ fields:
 {{- end -}}
 {{if .meta.fields.reporter}}
   reporter:
-    name: {{if .overrides.reporter}}{{.overrides.reporter}}{{else}}{{if .fields.reporter}}{{.fields.reporter.name}}{{end}}{{end}}
+    name: {{if .overrides.reporter}}{{.overrides.reporter}}{{else}}{{if .fields.reporter}}{{.fields.reporter.displayName}}{{end}}{{end}}
 {{- end -}}
 {{if .meta.fields.resolution}}
   resolution: # Values: {{ range .meta.fields.resolution.allowedValues }}{{.name}}, {{end}}

--- a/jiracmd/take.go
+++ b/jiracmd/take.go
@@ -19,7 +19,7 @@ func CmdTakeRegistry() *jiracli.CommandRegistryEntry {
 		func(o *oreo.Client, globals *jiracli.GlobalOptions) error {
 			opts.Issue = jiracli.FormatIssue(opts.Issue, opts.Project)
 			if opts.Assignee == "" {
-				opts.Assignee = globals.User.Value
+				opts.Assignee = globals.AccountId.Value
 			}
 			return CmdAssign(o, globals, &opts)
 		},

--- a/jiracmd/watch.go
+++ b/jiracmd/watch.go
@@ -60,7 +60,7 @@ func CmdWatchUsage(cmd *kingpin.CmdClause, opts *WatchOptions) error {
 // with the 'remove' flag)
 func CmdWatch(o *oreo.Client, globals *jiracli.GlobalOptions, opts *WatchOptions) error {
 	if opts.Watcher == "" {
-		opts.Watcher = globals.User.Value
+		opts.Watcher = globals.AccountId.Value
 	}
 	if opts.Action == WatcherAdd {
 		if err := jira.IssueAddWatcher(o, globals.Endpoint.Value, opts.Issue, opts.Watcher); err != nil {


### PR DESCRIPTION
Adds `account-id` parameter to config parsing
Uses `accountId` parameter instead of `user` or `name` for `watch`, and `assign` issue commands

I have tested the functionality and can confirm the functionality acts as expected. This being said, I am relatively new to go, and have not gone through the trouble of figuring out how to run the automated tests, or even which tests need to be modified given these changes. Please feel free to advise.

This PR should fix issue https://github.com/go-jira/jira/issues/314

Thanks