### PR TITLE
Remove myself as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # one of these users must approve the PR before merging
-* @coryb @mvdan @vanniktech @mikepea
+* @coryb @mvdan @mikepea


### PR DESCRIPTION
Frankly, I've stopped using this since I went from being employed to freelance and only a few of my clients are using Jira.