### PR TITLE
transition: map field name to id

### DIFF
--- a/jiracmd/transition.go
+++ b/jiracmd/transition.go
@@ -165,6 +165,26 @@ func CmdTransition(o *oreo.Client, globals *jiracli.GlobalOptions, opts *Transit
 				return err
 			}
 		}
+
+		// if issueUpdate contains fields lets see if we can map them
+		// to their ids
+		if len(issueUpdate.Fields) > 0 {
+			fields, err := jira.GetFields(o, globals.Endpoint.Value)
+			if err != nil {
+				return err
+			}
+			for k, v := range issueUpdate.Fields {
+				for _, f := range fields {
+					if f.Name == k {
+						// re-map to field.id
+						issueUpdate.Fields[f.ID] = v
+						delete(issueUpdate.Fields, k)
+						break
+					}
+				}
+			}
+		}
+
 		return jira.TransitionIssue(o, globals.Endpoint.Value, opts.Issue, &issueUpdate)
 	})
 	if err != nil {


### PR DESCRIPTION
this commit allows a user to use the more friendly field.Name when
transitioning to states which require custom field inputs.

For example our workflow requires a git pull request field and this is now possible:

```
fields:
  "Git Pull Request": https://github.com/example
  transition:
    id: 711
    name: Link Pull Request
```

It is possible this functionality exists in some other way - but could not get it to work without the provided diff. 

Signed-off-by: ldelossa <ldelossa@redhat.com>