### PR TITLE
username-deprecation: use email and display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 Simple command line client for Atlassian's Jira service written in Go.
 
+## GDPR USERNAME DISCLAIMER
+
+When this tool was initial written the "username" parameter was widely used in the Atlassian API.
+Due to GDPR restrictions this parameter was been almost completely phased out other then V1 login.
+The "--user" field is still provided as a default global, however moving forward any usage of this field should be phased out in favor of the "--login" option. 
+
+Commands which previously took a username will now expect an email address such as watch, create, assign, etc...
+
 ## Install
 
 ### Download

--- a/issue.go
+++ b/issue.go
@@ -499,7 +499,7 @@ func (j *Jira) IssueRemoveWatcher(issue, user string) error {
 
 func IssueRemoveWatcher(ua HttpClient, endpoint string, issue, user string) error {
 	uri := URLJoin(endpoint, "rest/api/2/issue", issue, "watchers")
-	uri += fmt.Sprintf("?username=%s", user)
+	uri += fmt.Sprintf("?accountId=%s", user)
 	resp, err := ua.Delete(uri)
 	if err != nil {
 		return err

--- a/jiracmd/assign.go
+++ b/jiracmd/assign.go
@@ -43,7 +43,7 @@ func CmdAssignUsage(cmd *kingpin.CmdClause, opts *AssignOptions) error {
 		return nil
 	}).Bool()
 	cmd.Arg("ISSUE", "issue to assign").Required().StringVar(&opts.Issue)
-	cmd.Arg("ASSIGNEE", "user to assign to issue").StringVar(&opts.Assignee)
+	cmd.Arg("ASSIGNEE", "email or display name of user to assign to issue").StringVar(&opts.Assignee)
 	return nil
 }
 
@@ -61,7 +61,7 @@ func CmdAssign(o *oreo.Client, globals *jiracli.GlobalOptions, opts *AssignOptio
 	if globals.JiraDeploymentType.Value == jiracli.CloudDeploymentType {
 		if opts.Assignee != "" && opts.Assignee != "-1" {
 			users, err := jira.UserSearch(o, globals.Endpoint.Value, &jira.UserSearchOptions{
-				Username: opts.Assignee,
+				Query: opts.Assignee,
 			})
 			if err != nil {
 				return err

--- a/jiracmd/edit.go
+++ b/jiracmd/edit.go
@@ -180,20 +180,6 @@ func fixUserField(ua jira.HttpClient, endpoint string, userField map[string]inte
 		return nil
 	}
 
-	if username, ok := userField["name"].(string); ok {
-		users, err := jira.UserSearch(ua, endpoint, &jira.UserSearchOptions{
-			Username: username,
-		})
-		if err != nil {
-			return err
-		}
-		if len(users) != 1 {
-			return fmt.Errorf("Found %d accounts for username %q", len(users), username)
-		}
-		userField["accountId"] = users[0].AccountID
-		return nil
-	}
-
 	queryName, ok := userField["displayName"].(string)
 	if !ok {
 		queryName, ok = userField["emailAddress"].(string)

--- a/jiracmd/take.go
+++ b/jiracmd/take.go
@@ -19,7 +19,7 @@ func CmdTakeRegistry() *jiracli.CommandRegistryEntry {
 		func(o *oreo.Client, globals *jiracli.GlobalOptions) error {
 			opts.Issue = jiracli.FormatIssue(opts.Issue, opts.Project)
 			if opts.Assignee == "" {
-				opts.Assignee = globals.User.Value
+				opts.Assignee = globals.Login.Value
 			}
 			return CmdAssign(o, globals, &opts)
 		},

--- a/jiracmd/watch.go
+++ b/jiracmd/watch.go
@@ -53,7 +53,7 @@ func CmdWatchUsage(cmd *kingpin.CmdClause, opts *WatchOptions) error {
 		return nil
 	}).Bool()
 	cmd.Arg("ISSUE", "issue to add watcher").Required().StringVar(&opts.Issue)
-	cmd.Arg("WATCHER", "username of watcher to add to issue").StringVar(&opts.Watcher)
+	cmd.Arg("WATCHER", "email or display name of watcher to add to issue").StringVar(&opts.Watcher)
 	return nil
 }
 
@@ -61,7 +61,7 @@ func CmdWatchUsage(cmd *kingpin.CmdClause, opts *WatchOptions) error {
 // with the 'remove' flag)
 func CmdWatch(o *oreo.Client, globals *jiracli.GlobalOptions, opts *WatchOptions) error {
 	if opts.Watcher == "" {
-		opts.Watcher = globals.User.Value
+		opts.Watcher = globals.Login.Value
 	}
 
 	if globals.JiraDeploymentType.Value == "" {
@@ -74,7 +74,7 @@ func CmdWatch(o *oreo.Client, globals *jiracli.GlobalOptions, opts *WatchOptions
 
 	if globals.JiraDeploymentType.Value == jiracli.CloudDeploymentType {
 		users, err := jira.UserSearch(o, globals.Endpoint.Value, &jira.UserSearchOptions{
-			Username: opts.Watcher,
+			Query: opts.Watcher,
 		})
 		if err != nil {
 			return err

--- a/users.go
+++ b/users.go
@@ -26,9 +26,6 @@ func UserSearch(ua HttpClient, endpoint string, opts *UserSearchOptions) ([]*jir
 	if opts.Query != "" {
 		params = append(params, "query="+url.QueryEscape(opts.Query))
 	}
-	if opts.Username != "" {
-		params = append(params, "username="+url.QueryEscape(opts.Username))
-	}
 	if opts.AccountID != "" {
 		params = append(params, "accountId="+url.QueryEscape(opts.AccountID))
 	}


### PR DESCRIPTION
this commit deprecates the searching ability by username and
instructs user to provide email or display names in commands.

the username parameter has been deprecated completely from v2 and v3
api

Signed-off-by: ldelossa <ldelossa@redhat.com>