### PR TITLE
cicd: deflake tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
 
 env:


### PR DESCRIPTION
this commit removes the parallel test matrix as parallel testing runs
the potention of trampling one another

Signed-off-by: ldelossa <ldelossa@redhat.com>