### PR TITLE
Make -h flag show --help

### DIFF
--- a/jiracli/usage.go
+++ b/jiracli/usage.go
@@ -103,6 +103,7 @@ Commands:
 
 func CommandLine(fig *figtree.FigTree, o *oreo.Client) *kingpin.Application {
 	app := kingpin.New("jira", "Jira Command Line Interface")
+	app.HelpFlag.Short('h')
 	app.UsageWriter(os.Stdout)
 	app.ErrorWriter(os.Stderr)
 	app.Command("version", "Prints version").PreAction(func(*kingpin.ParseContext) error {


### PR DESCRIPTION
See https://github.com/alecthomas/kingpin#supporting--h-for-help
This brings a short option to `--help` like all the other flags)

Tested with:

```
make
./jira -h
```