### PR TITLE
Support empty responses in request commands

### DIFF
--- a/jiracmd/request.go
+++ b/jiracmd/request.go
@@ -72,6 +72,9 @@ func CmdRequest(o *oreo.Client, globals *jiracli.GlobalOptions, opts *RequestOpt
 	if err != nil {
 		return err
 	}
+	if resp.Body == nil {
+		return fmt.Errorf("Empty Response Body")
+	}
 	defer resp.Body.Close()
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/jiracmd/request.go
+++ b/jiracmd/request.go
@@ -3,12 +3,12 @@ package jiracmd
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"strings"
 
 	"github.com/coryb/figtree"
 	"github.com/coryb/oreo"
-
 	"github.com/go-jira/jira/jiracli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
@@ -74,8 +74,17 @@ func CmdRequest(o *oreo.Client, globals *jiracli.GlobalOptions, opts *RequestOpt
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Response Body read Error: %v", err)
+	}
+	if len(bodyBytes) == 0 {
+		log.Info("Empty response for status %d", resp.StatusCode)
+		return nil
+	}
+
 	var data interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+	if err := json.Unmarshal(bodyBytes, &data); err != nil {
 		return fmt.Errorf("JSON Parse Error: %v", err)
 	}
 	return opts.PrintTemplate(&data)


### PR DESCRIPTION
Avoid JSON parser when the response is empty - common cases for HTTP 204 in issues deletion, or moving issues to sprint.

Bellow the example of first running with my branch build and second with the last release.
![Screen Shot 2020-09-07 at 12 12 38 PM](https://user-images.githubusercontent.com/1316207/92413121-764a5400-f103-11ea-8c10-e6a0a0d17ad2.png)
