### PR TITLE
templates: add wrap helper function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
+	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/olekukonko/tablewriter v0.0.3
 	github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/mattn/go-runewidth v0.0.6 h1:V2iyH+aX9C5fsYCpK60U8BYIvmhqxuOL3JZcqc1N
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/olekukonko/tablewriter v0.0.3 h1:i0LBnzgiChAWHJYTQAZJDOgf8MNxAVYZJ2m63SIDimI=
 github.com/olekukonko/tablewriter v0.0.3/go.mod h1:YZeBtGzYYEsCHp2LST/u/0NDwGkRoBtmn1cIWCJiS6M=
 github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15 h1:mrI+6Ae64Wjt+uahGe5we/sPS1sXjvfT3YjtawAVgps=

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -21,6 +21,7 @@ import (
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/mgutz/ansi"
 	"github.com/olekukonko/tablewriter"
+	wordwrap "github.com/mitchellh/go-wordwrap"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -190,6 +191,9 @@ func TemplateProcessor() *template.Template {
 		},
 		"dateFormat": func(format string, content string) (string, error) {
 			return dateFormat(format, content)
+		},
+		"wrap": func(width uint, content string) string {
+			return wordwrap.WrapString(content, width)
 		},
 	}
 	return template.New("gojira").Funcs(sprig.GenericFuncMap()).Funcs(funcs)


### PR DESCRIPTION
Add "wrap" command to TemplateProcessor.  Use
github.com/mitchellh/go-wordwrap to wrap lines on word breaks at
a given length.  This can make long fields much more readable in
a terminal.  E.g.

	{{ .fields.description | wrap 76 | indent 2}}