### PR TITLE
block: reverse order of arguments

### DIFF
--- a/jiracmd/block.go
+++ b/jiracmd/block.go
@@ -56,8 +56,8 @@ func CmdBlockUsage(cmd *kingpin.CmdClause, opts *BlockOptions) error {
 		}
 		return nil
 	}).String()
-	cmd.Arg("BLOCKER", "blocker issue").Required().StringVar(&opts.OutwardIssue.Key)
-	cmd.Arg("ISSUE", "issue that is blocked").Required().StringVar(&opts.InwardIssue.Key)
+	cmd.Arg("ISSUE", "issue that is blocked").Required().StringVar(&opts.OutwardIssue.Key)
+	cmd.Arg("BLOCKER", "blocker issue").Required().StringVar(&opts.InwardIssue.Key)
 	return nil
 }
 


### PR DESCRIPTION
The BLOCKER and ISSUE arguments for the block command were incorrect.
With hypothetical ticket names BLOCKER and ISSUE, calling

	jira block BLOCKER ISSUE

resulted in

	ISSUE blocks BLOCKER
	BLOCKER is blocked by ISSUE

which is the reverse of the documentation which claims it should be

	BLOCKER blocks ISSUE
	ISSUE is blocked by BLOCKER

Reverse order of the arguments so the documentation matches the
actual usage.  This does not break existing usage, only updates the
documentation.

Fixes #383