### PR TITLE
Move the session cookie to $XDG_RUNTIME_DIR

### DIFF
--- a/cmd/jira/main.go
+++ b/cmd/jira/main.go
@@ -45,7 +45,12 @@ func main() {
 		panic(jiracli.Exit{Code: 1})
 	}
 
-	o := oreo.New().WithCookieFile(filepath.Join(jiracli.Homedir(), configDir, "cookies.js")).WithLogger(&oreoLogger{log})
+	if err := os.MkdirAll(filepath.Join(jiracli.Cookiedir(), configDir), 0700); err != nil {
+		log.Errorf("%s", err)
+		panic(jiracli.Exit{Code: 1})
+	}
+
+	o := oreo.New().WithCookieFile(filepath.Join(jiracli.Cookiedir(), configDir, "cookies.js")).WithLogger(&oreoLogger{log})
 
 	jiracmd.RegisterAllCommands()
 

--- a/jiracli/util.go
+++ b/jiracli/util.go
@@ -21,6 +21,14 @@ func Homedir() string {
 	return os.Getenv("HOME")
 }
 
+func Cookiedir() string {
+    value, exists := os.LookupEnv("XDG_RUNTIME_DIR")
+    if !exists {
+        value = Homedir()
+    }
+    return value
+}
+
 func findClosestParentPath(fileName string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Before this commit the session cookie and its corresponding lock file
would be placed in the user's home directory. Sadly this breaks all
setups that configure the user's home to live on a NFS mount. File
locking on NFS mounts is something that doesn't work reliably and thus
causes some users to experience issues like this:

    Failed to save cookie file: bad file descriptor

To counteract, this commit instead stores this data in the
$XDG_RUNTIME_DIR which is a directory that is usually located on the
local disk or even located in runtime memory.

This commit will most likely slightly change the behaviour of how
persistent the session data will be stored since often $XDG_RUNTIME_DIR
will be cleared on logout of the user.

Fixes: #290