### PR TITLE
Load config on "jira browse"

### DIFF
--- a/jiracmd/browse.go
+++ b/jiracmd/browse.go
@@ -21,6 +21,7 @@ func CmdBrowseRegistry() *jiracli.CommandRegistryEntry {
 		"Open issue in browser",
 		func(fig *figtree.FigTree, cmd *kingpin.CmdClause) error {
 			cmd.Arg("ISSUE", "Issue to browse to").Required().StringVar(&opts.Issue)
+			jiracli.LoadConfigs(cmd, fig, &opts)
 			return nil
 		},
 		func(o *oreo.Client, globals *jiracli.GlobalOptions) error {


### PR DESCRIPTION
This is done in order to ensure consistency with the other commands on how the configuration files are loaded. I found out about it when I had set up a global project, but the "jira browse 1234" command complained about missing project.