### PR TITLE
jiraExec Template Function

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -14,15 +15,15 @@ import (
 	"strings"
 	"text/template"
 
-	yaml "gopkg.in/coryb/yaml.v2"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/Masterminds/sprig"
 	"github.com/coryb/figtree"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/mgutz/ansi"
-	"github.com/olekukonko/tablewriter"
 	wordwrap "github.com/mitchellh/go-wordwrap"
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/olekukonko/tablewriter"
+	yaml "gopkg.in/coryb/yaml.v2"
 )
 
 func findTemplate(name string) ([]byte, error) {
@@ -70,6 +71,17 @@ func TemplateProcessor() *template.Template {
 	funcs := map[string]interface{}{
 		"jira": func() string {
 			return os.Args[0]
+		},
+		"jiraExec": func(args ...string) *exec.Cmd {
+			var outb, errb bytes.Buffer
+			cmd := exec.Command(os.Args[0], args...)
+			cmd.Stdout = &outb
+			cmd.Stderr = &errb
+			err := cmd.Run()
+			if err != nil {
+				log.Warning("error running %v: %v", cmd.Args, err)
+			}
+			return cmd
 		},
 		"env": func() map[string]string {
 			out := map[string]string{}


### PR DESCRIPTION
This adds a `jiraExec` template function that executes a jira command and returns the result, logging an error if one is encountered. This is useful, for example, if you want to parse Github links in an issue description and change output based on CI or reviews.