### PR TITLE
Update (miscopied?) description of rank command

### DIFF
--- a/jiracmd/rank.go
+++ b/jiracmd/rank.go
@@ -24,7 +24,7 @@ func CmdRankRegistry() *jiracli.CommandRegistryEntry {
 	opts := RankOptions{}
 
 	return &jiracli.CommandRegistryEntry{
-		"Mark issues as blocker",
+		"Change ranking of issue",
 		func(fig *figtree.FigTree, cmd *kingpin.CmdClause) error {
 			jiracli.LoadConfigs(cmd, fig, &opts)
 			return CmdRankUsage(cmd, &opts)


### PR DESCRIPTION
This looked like an artifact of a copy/paste sorta situation: the current description for the `rank` command has the description for the `block` command.

I ad libbed a new description that is hopefully at least _more_ correct 😄