### PR TITLE
Correct rank command help string

### DIFF
--- a/jiracmd/rank.go
+++ b/jiracmd/rank.go
@@ -24,7 +24,7 @@ func CmdRankRegistry() *jiracli.CommandRegistryEntry {
 	opts := RankOptions{}
 
 	return &jiracli.CommandRegistryEntry{
-		"Mark issues as blocker",
+		"Rank issue before/after other issue",
 		func(fig *figtree.FigTree, cmd *kingpin.CmdClause) error {
 			jiracli.LoadConfigs(cmd, fig, &opts)
 			return CmdRankUsage(cmd, &opts)


### PR DESCRIPTION
Apparently the help text was inadvertently preserved when `rank` was created from a copy of `block`.