### PR TITLE
Fix when issue type's name has a translation

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -283,7 +283,7 @@ func (j *Jira) GetIssueCreateMetaIssueType(projectKey, issueTypeName string) (*j
 
 func GetIssueCreateMetaIssueType(ua HttpClient, endpoint string, projectKey, issueTypeName string) (*jiradata.IssueType, error) {
 	uri := URLJoin(endpoint, "rest/api/2/issue/createmeta")
-	uri += fmt.Sprintf("?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", projectKey, url.QueryEscape(issueTypeName))
+	uri += fmt.Sprintf("?projectKeys=%s&expand=projects.issuetypes.fields", projectKey)
 	resp, err := ua.GetJSON(uri)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Problem :**
When an _issue type_ has a translation for its name, it is impossible to create an issue with that _issue type_ (error appears when the original name and its translation are different).

Indeed, in `Jira Administation / Issues / Issue types`, it is possible to set a translation for each _issue type_ with `Translate Action`.

For example, when creating a _Bug_ issue with and without translation (tested with an instance of _Atlassian Jira_  `v8.18.0`) :
```sh
## No translation ##

# List issuetypes
$ jira issuetypes
Task:         A task that needs to be done.
Sub-task:     The sub-task of the issue
Story:        Created by Jira Software - do not edit or delete. Issue type for a user story.
Bug:          A problem which impairs or prevents the functions of the product.
Epic:         Created by Jira Software - do not edit or delete. Issue type for a big user story that needs to be broken down.

# Creating an issue
$ jira create --issuetype Bug
OK TEST-24 http://JIRA_DOMAIN/browse/TEST-24


## With translation: 'Bug' -> 'Bogue' ##

# List issuetypes
$ jira issuetypes
Task:         A task that needs to be done.
Sub-task:     The sub-task of the issue
Story:        Created by Jira Software - do not edit or delete. Issue type for a user story.
Bogue:        Bogue Bogue
Epic:         Created by Jira Software - do not edit or delete. Issue type for a big user story that needs to be broken down.

$ jira create --issuetype Bug
ERROR Invalid Usage: project TEST and IssueType Bug not found

$ jira create --issuetype Bogue
ERROR Invalid Usage: project TEST and IssueType Bogue not found
```

**Cause :**
This error message comes from the function `GetIssueCreateMetaIssueType()` in `issue.go` :
```go
func GetIssueCreateMetaIssueType(ua HttpClient, endpoint string, projectKey, issueTypeName string) (*jiradata.IssueType, error) {
	uri := URLJoin(endpoint, "rest/api/2/issue/createmeta")
	uri += fmt.Sprintf("?projectKeys=%s&issuetypeNames=%s&expand=projects.issuetypes.fields", projectKey, url.QueryEscape(issueTypeName))
	...
	for _, project := range results.Projects {
		if project.Key != projectKey {
			continue
		}
		for _, issueType := range project.IssueTypes {
			if issueType.Name == issueTypeName {
				return issueType, nil
			}
		}
	}
	return nil, fmt.Errorf("project %s and IssueType %s not found", projectKey, issueTypeName)
}
```
This error happens because when an _issue type_ has a translation on its name, the request `GET .../createmeta` returns data about the _issue type_ **only when** `issuetypeNames` parameter contains the **original name** (_"Bug"_ in the example), whereas when searching for the _issue type_ in the response, `issueType.Name` is the **translation** (_"Bogue"_ in the example when `issueTypeName="Bug"`).
As a result, `issuetypeName` cannot be found in the response.

**Solution :**
Removing `issuetypeNames` parameter to get every _issue types_ from the project :
```go
func GetIssueCreateMetaIssueType(ua HttpClient, endpoint string, projectKey, issueTypeName string) (*jiradata.IssueType, error) {
	uri := URLJoin(endpoint, "rest/api/2/issue/createmeta")
	uri += fmt.Sprintf("?projectKeys=%s&expand=projects.issuetypes.fields", projectKey)
	...
}
```

However, as it get every _issue types_ with the `expand` parameter, a lot more useless data is also downloaded.

Another solution would be to keep the original request, but when the _issue type_ is not found, this other request would be used.

I don't know what would be better.
In this fix, I made the easiest but probably not the cleanest solution.