### PR TITLE
Add authentication-method: bearer-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,17 @@ The API Token authentication requires both the token and the email of the user. 
 
 If your Jira service still allows you to use the Session based authentication method then `jira` will prompt for a password automatically when get a response header from the Jira service that indicates you do not have an active session (ie the `X-Ausername` header is set to `anonymous`).  Then after authentication we cache the `cloud.session.token` cookie returned by the service [session login api](https://docs.atlassian.com/jira/REST/cloud/#auth/1/session-login) and reuse that on subsequent requests.  Typically this cookie will be valid for several hours (depending on the service configuration).  To automatically securely store your password for easy reuse by jira You can enable a `password-source` via `.jira.d/config.yml` with possible values of `keyring`, `pass` or `gopass`.
 
+Depending on how your private Jira service is configured, API tokens may require the "[Bearer][]" authentication scheme instead of the traditional "[Basic][]" [authentication scheme][scheme]. In this case, set the `authentication-method: bearer-token` property in your `$HOME/.jira.d/config.yml` file.
+
+[scheme]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes
+[Bearer]: https://datatracker.ietf.org/doc/html/rfc6750
+[Basic]: https://tools.ietf.org/html/rfc7617
+
+| **API token [scheme][]** | `authentication-method` | **Example HTTP request header**                 |
+|:------------------------:|-------------------------|-------------------------------------------------|
+|        [Basic][]         | `api-token`             | `Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQK` |
+|        [Bearer][]        | `bearer-token`          | `Authorization: Bearer MY_TOKEN`                |
+
 #### User vs Login
 The Jira service has sometimes differing opinions about how a user is identified.  In other words the ID you login with might not be ID that the jira system recognized you as.  This matters when trying to identify a user via various Jira REST APIs (like issue assignment).  This is especially relevant when trying to authenticate with an API Token where the authentication user is usually an email address, but within the Jira system the user is identified by a user name.  To accommodate this `jira` now supports two different properties in the config file.  So when authentication using the API Tokens you will likely want something like this in your `$HOME/.jira.d/config.yml` file:
 ```yaml

--- a/jiracli/cli.go
+++ b/jiracli/cli.go
@@ -173,7 +173,11 @@ func register(app *kingpin.Application, o *oreo.Client, fig *figtree.FigTree) {
 			token := globals.GetPass()
 			authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", globals.Login.Value, token))))
 			req.Header.Add("Authorization", authHeader)
-		}
+		} else if globals.AuthMethod() == "bearer-token" {
+			token := globals.GetPass()
+			authHeader := fmt.Sprintf("Bearer %s", token)
+			req.Header.Add("Authorization", authHeader)
+                }
 		return req, nil
 	})
 

--- a/jiracmd/login.go
+++ b/jiracmd/login.go
@@ -50,6 +50,10 @@ func CmdLogin(o *oreo.Client, globals *jiracli.GlobalOptions, opts *jiracli.Comm
 		log.Noticef("No need to login when using api-token authentication method")
 		return nil
 	}
+	if globals.AuthMethod() == "bearer-token" {
+		log.Noticef("No need to login when using bearer-token authentication method")
+		return nil
+	}
 
 	ua := o.WithoutRedirect().WithRetries(0).WithoutCallbacks().WithPostCallback(authCallback)
 	for {

--- a/jiracmd/logout.go
+++ b/jiracmd/logout.go
@@ -30,13 +30,13 @@ func CmdLogoutRegistry() *jiracli.CommandRegistryEntry {
 
 // CmdLogout will attempt to terminate an active Jira session
 func CmdLogout(o *oreo.Client, globals *jiracli.GlobalOptions, opts *jiracli.CommonOptions) error {
-	if globals.AuthMethod() == "api-token" {
-		log.Noticef("No need to logout when using api-token authentication method")
+	if (globals.AuthMethod() == "api-token" || globals.AuthMethod() == "bearer-token") {
+		log.Noticef("No need to logout when using api-token or bearer-token authentication method")
 		if globals.GetPass() != "" && terminal.IsTerminal(int(os.Stdin.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd())) {
 			delete := false
 			err := survey.AskOne(
 				&survey.Confirm{
-					Message: fmt.Sprintf("Delete api-token from password provider [%s]: ", globals.PasswordSource),
+					Message: fmt.Sprintf("Delete token from password provider [%s]: ", globals.PasswordSource),
 					Default: false,
 				},
 				&delete,


### PR DESCRIPTION
Hi, thanks for the neat tool.

For some reason, our private Jira installation requires the Bearer authentication scheme for API tokens, instead of Basic authentication. I don't know the reason - perhaps it's because there is SAML configured.

Anyway, this patch adds support for such configurations.

Cheers
