### PR TITLE
feat: add `defaultColWidth` template function

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -263,6 +263,10 @@ func RunTemplate(templateName string, data interface{}, out io.Writer) error {
 	headers := []string{}
 	cells := [][]string{}
 	tmpl, err := TemplateProcessor().Funcs(map[string]interface{}{
+		"defaultColWidth": func(cw int) string {
+			table.SetColWidth(cw)
+			return ""
+		},
 		"headers": func(titles ...string) string {
 			headers = append(headers, titles...)
 			return ""


### PR DESCRIPTION
This function can be used in templates to change the default column
width to accommodate wider terminals.