### PR TITLE
add --passwordsource global option

### DIFF
--- a/jiracli/cli.go
+++ b/jiracli/cli.go
@@ -166,6 +166,7 @@ func register(app *kingpin.Application, o *oreo.Client, fig *figtree.FigTree) {
 	app.Flag("socksproxy", "Address for a socks proxy").SetValue(&globals.SocksProxy)
 	app.Flag("user", "user name used within the Jira service").Short('u').SetValue(&globals.User)
 	app.Flag("login", "login name that corresponds to the user used for authentication").SetValue(&globals.Login)
+	app.Flag("passwordsource", "Method to fetch the password").SetValue(&globals.PasswordSource)
 
 	o = o.WithPreCallback(func(req *http.Request) (*http.Request, error) {
 		if globals.AuthMethod() == "api-token" {

--- a/jiracli/password.go
+++ b/jiracli/password.go
@@ -3,7 +3,6 @@ package jiracli
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -118,11 +117,12 @@ func (o *GlobalOptions) GetPass() string {
 			}
 		} else if o.PasswordSource.Value == "stdin" {
 			log.Info("Reading password from stdin.")
-			allBytes, err := ioutil.ReadAll(os.Stdin)
+			var buffer [512]byte
+			nBytes, err := os.Stdin.Read(buffer[:])
 			if err != nil {
 				panic(fmt.Sprintf("unable to read bytes from stdin: %s", err))
 			}
-			o.cachedPassword = string(allBytes)
+			o.cachedPassword = string(buffer[:nBytes-1])
 		} else {
 			log.Warningf("Unknown password-source: %s", o.PasswordSource)
 		}


### PR DESCRIPTION
for automation testing and/or CI/CD, it's good to have pipe login from stdin. at present we need add "password-source: stdin" in .jira.d/config.yml, it's not convenient. this pull request would better :

echo "password" | jira login --passwordsource stdin