### PR TITLE
fix assignee: expected Object containing a name property

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -562,7 +562,7 @@ fields:
     emailAddress: {{ .overrides.assignee }}
   {{- else if .fields.assignee }}
   assignee: {{if .fields.assignee.name}}
-    emailAddress: {{ or .fields.assignee.name}}
+    name: {{ or .fields.assignee.name}}
   {{- else }}
     emailAddress: {{.fields.assignee.emailAddress}}{{end}}{{end}}
 {{- end -}}


### PR DESCRIPTION
### Summary
Modifies default transition template based on suggestion from https://github.com/go-jira/jira/issues/414. This fixes a bug where certain projects could not have their issues transitioned by the CLI


### Test Plan
Run `jira in-progress --noedit <ID>` on issues that belong to projects that have usernames mapped to addresses as well as regular usernames