### PR TITLE
Added the more info if command get failed

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/url"
 	"strings"
@@ -68,9 +69,35 @@ func GetIssue(ua HttpClient, endpoint string, issue string, iqg IssueQueryProvid
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 200 {
+
 		results := &jiradata.Issue{}
-		return results, json.NewDecoder(resp.Body).Decode(results)
+		json_error := json.NewDecoder(resp.Body).Decode(results)
+
+		if json_error != nil {
+
+			log.Print("status Code: ", resp.Status, ", URL: ", uri)
+
+			bodyBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				log.Fatal(err)
+			}
+			bodyString := string(bodyBytes)
+			log.Fatalf(bodyString)
+
+		}
+		return results, json_error
+	} else {
+
+		log.Print("status Code: ", resp.Status, ", URL: ", uri)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		bodyString := string(bodyBytes)
+		log.Fatalf(bodyString)
+
 	}
+
 	return nil, responseError(resp)
 }
 


### PR DESCRIPTION
sometimes it gives html rather then the json and due to this it's very hard to get what is the output only i get
Invalid Usage: invalid character '<' looking for beginning of value, may be some problem with jira api call and when i rerun the command it works fine  but it's good to have output when it gives any error and also if i use -vvv more verbose it's show authorization bearer token on that and i don't want  to show it.

