### PR TITLE
Make Templates Readable

### DIFF
--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -442,8 +442,8 @@ fields:
     emailAddress: {{ or .fields.assignee.name}}
   {{- else }}
     emailAddress: {{.fields.assignee.emailAddress}}
-  {{end}}{{end}}
-{{end}}
+  {{-end}}{{end}}
+{{-end}}
 {{- if .meta.fields.reporter}}
   reporter:
     emailAddress: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.emailAddress }}{{end}}

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -531,21 +531,32 @@ fields:
   # Epic Name
   customfield_10120: {{ or (index .overrides "epic-name") "" }}
   summary: >-
-    {{ or .overrides.summary "" }}{{if .meta.fields.priority.allowedValues}}
+    {{ or .overrides.summary "" }}
+{{if .meta.fields.priority.allowedValues}}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
-    name: {{ or .overrides.priority ""}}{{end}}{{if .meta.fields.components.allowedValues}}
-  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{ range split "," (or .overrides.components "")}}
-    - name: {{ . }}{{end}}{{end}}
+    name: {{ or .overrides.priority ""}}
+{{end}}
+{{if .meta.fields.components.allowedValues}}
+  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}
+  {{ range split "," (or .overrides.components "")}}
+    - name: {{ . }}{{end}}
+{{end}}
   description: |~
-    {{ or .overrides.description "" | indent 4 }}{{if .meta.fields.assignee}}
+    {{ or .overrides.description "" | indent 4 }}
+{{if .meta.fields.assignee}}
   assignee:
-    emailAddress: {{ or .overrides.assignee "" }}{{end}}{{if .meta.fields.reporter}}
+    emailAddress: {{ or .overrides.assignee "" }}
+{{end}}
+{{if .meta.fields.reporter}}
   reporter:
-    emailAddress: {{ or .overrides.reporter .overrides.login }}{{end}}{{if .meta.fields.customfield_10110}}
+    emailAddress: {{ or .overrides.reporter .overrides.login }}
+{{end}}
+{{if .meta.fields.customfield_10110}}
   # watchers
   customfield_10110: {{ range split "," (or .overrides.watchers "")}}
     - name: {{.}}{{end}}
-    - name:{{end}}
+    - name:
+{{end}}
   issuetype:
     name: Epic`
 

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -461,7 +461,7 @@ fields:
 {{- if .meta.fields.priority }}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
     name: {{ or .overrides.priority .fields.priority.name "" }}
-{{end}}
+{{- end}}
   description: |~
     {{ or .overrides.description .fields.description "" | indent 4 }}
 # votes: {{ .fields.votes.votes }}

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -451,13 +451,13 @@ fields:
 {{- if .meta.fields.customfield_10110}}
   # watchers
   customfield_10110:
-  {{ range .fields.customfield_10110 }}
+  {{- range .fields.customfield_10110 }}
     - name: {{ .name }}
-  {{end}}
-  {{if .overrides.watcher}}
+  {{- end}}
+  {{- if .overrides.watcher}}
     - name: {{ .overrides.watcher}}
-  {{end}}
-{{end}}
+  {{- end}}
+{{- end}}
 {{- if .meta.fields.priority }}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
     name: {{ or .overrides.priority .fields.priority.name "" }}

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -610,9 +610,14 @@ fields:
     emailAddress: {{.fields.assignee.emailAddress}}{{end}}{{end}}
 {{- end -}}
 {{if .meta.fields.components}}
-  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{if .overrides.components }}{{ range (split "," .overrides.components)}}
-    - name: {{.}}{{end}}{{else}}{{ range .fields.components }}
-    - name: {{ .name }}{{end}}{{end}}
+  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}
+  {{if .overrides.components }}
+  {{ range (split "," .overrides.components)}}
+    - name: {{.}}{{end}}
+  {{else}}
+  {{ range .fields.components }}
+    - name: {{ .name }}{{end}}
+  {{end}}
 {{- end -}}
 {{if .meta.fields.description}}
   description: |~
@@ -620,9 +625,14 @@ fields:
 {{- end -}}
 {{if .meta.fields.fixVersions -}}
   {{if .meta.fields.fixVersions.allowedValues}}
-  fixVersions: # Values: {{ range .meta.fields.fixVersions.allowedValues }}{{.name}}, {{end}}{{if .overrides.fixVersions}}{{ range (split "," .overrides.fixVersions)}}
-    - name: {{.}}{{end}}{{else}}{{range .fields.fixVersions}}
-    - name: {{.name}}{{end}}{{end}}
+  fixVersions: # Values: {{ range .meta.fields.fixVersions.allowedValues }}{{.name}}, {{end}}
+    {{if .overrides.fixVersions}}
+    {{ range (split "," .overrides.fixVersions)}}
+    - name: {{.}}{{end}}
+    {{else}}
+    {{range .fields.fixVersions}}
+    - name: {{.name}}{{end}}
+    {{end}}
   {{- end -}}
 {{- end -}}
 {{if .meta.fields.issuetype}}
@@ -631,8 +641,11 @@ fields:
 {{- end -}}
 {{if .meta.fields.labels}}
   labels: {{range .fields.labels}}
-    - {{.}}{{end}}{{if .overrides.labels}}{{range (split "," .overrides.labels)}}
-    - {{.}}{{end}}{{end}}
+    - {{.}}{{end}}
+  {{if .overrides.labels}}
+  {{range (split "," .overrides.labels)}}
+    - {{.}}{{end}}
+  {{end}}
 {{- end -}}
 {{if .meta.fields.priority}}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
@@ -646,7 +659,8 @@ fields:
   reporter: {{if .fields.reporter.name}}
     name: {{ or .fields.reporter.name}}
   {{- else }}
-    displayName: {{.fields.reporter.displayName}}{{end}}{{end}}
+    displayName: {{.fields.reporter.displayName}}
+  {{end}}{{end}}
 {{- end -}}
 {{if .meta.fields.resolution}}
   resolution: # Values: {{ range .meta.fields.resolution.allowedValues }}{{.name}}, {{end}}
@@ -657,9 +671,14 @@ fields:
     {{or .overrides.summary .fields.summary}}
 {{- end -}}
 {{if .meta.fields.versions.allowedValues}}
-  versions: # Values: {{ range .meta.fields.versions.allowedValues }}{{.name}}, {{end}}{{if .overrides.versions}}{{ range (split "," .overrides.versions)}}
-    - name: {{.}}{{end}}{{else}}{{range .fields.versions}}
-    - name: {{.}}{{end}}{{end}}
+  versions: # Values: {{ range .meta.fields.versions.allowedValues }}{{.name}}, {{end}}
+  {{if .overrides.versions}}
+  {{ range (split "," .overrides.versions)}}
+    - name: {{.}}{{end}}
+  {{else}}
+  {{range .fields.versions}}
+    - name: {{.}}{{end}}
+  {{end}}
 {{- end}}
 transition:
   id: {{ .transition.id }}

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -477,21 +477,35 @@ fields:
   issuetype:
     name: {{ or .overrides.issuetype "" }}
   summary: >-
-    {{ or .overrides.summary "" }}{{if .meta.fields.priority.allowedValues}}
+    {{ or .overrides.summary "" }}
+{{if .meta.fields.priority.allowedValues}}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
-    name: {{ or .overrides.priority ""}}{{end}}{{if .meta.fields.components.allowedValues}}
-  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{ range split "," (or .overrides.components "")}}
-    - name: {{ . }}{{end}}{{end}}
+    name: {{ or .overrides.priority ""}}
+{{end}}
+{{if .meta.fields.components.allowedValues}}
+  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}
+  {{ range split "," (or .overrides.components "")}}
+    - name: {{ . }}
+  {{end}}
+{{end}}
   description: |~
-    {{ or .overrides.description "" | indent 4 }}{{if .meta.fields.assignee}}
+    {{ or .overrides.description "" | indent 4 }}
+{{if .meta.fields.assignee}}
   assignee:
-    emailAddress: {{ or .overrides.assignee "" }}{{end}}{{if .meta.fields.reporter}}
+    emailAddress: {{ or .overrides.assignee "" }}
+{{end}}
+{{if .meta.fields.reporter}}
   reporter:
-    emailAddress: {{ or .overrides.reporter .overrides.login }}{{end}}{{if .meta.fields.customfield_10110}}
+    emailAddress: {{ or .overrides.reporter .overrides.login }}
+{{end}}
+{{if .meta.fields.customfield_10110}}
   # watchers
-  customfield_10110: {{ range split "," (or .overrides.watchers "")}}
-    - name: {{.}}{{end}}
-    - name:{{end}}`
+  customfield_10110:
+  {{ range split "," (or .overrides.watchers "")}}
+    - name: {{.}}
+  {{end}}
+    - name:
+{{end}}`
 
 const defaultEpicCreateTemplate = `{{/* epic create template */ -}}
 fields:

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -446,8 +446,8 @@ fields:
 {{-end}}
 {{- if .meta.fields.reporter}}
   reporter:
-    emailAddress: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.emailAddress }}{{end}}
-{{end}}
+    emailAddress: {{ coalesce .overrides.reporter (.fields.reporter | .fields.reporter.emailAddress "") }}
+{{- end}}
 {{- if .meta.fields.customfield_10110}}
   # watchers
   customfield_10110:

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -554,21 +554,33 @@ fields:
   project:
     key: {{ .parent.fields.project.key }}
   summary: >-
-    {{ or .overrides.summary "" }}{{if .meta.fields.priority.allowedValues}}
+    {{ or .overrides.summary "" }}
+{{if .meta.fields.priority.allowedValues}}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
-    name: {{ or .overrides.priority ""}}{{end}}{{if .meta.fields.components.allowedValues}}
-  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{ range split "," (or .overrides.components "")}}
-    - name: {{ . }}{{end}}{{end}}
+    name: {{ or .overrides.priority ""}}
+{{end}}
+{{if .meta.fields.components.allowedValues}}
+  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}
+  {{ range split "," (or .overrides.components "")}}
+    - name: {{ . }}
+  {{end}}
+{{end}}
   description: |~
-    {{ or .overrides.description "" | indent 4 }}{{if .meta.fields.assignee}}
+    {{ or .overrides.description "" | indent 4 }}
+{{if .meta.fields.assignee}}
   assignee:
-    emailAddress: {{ or .overrides.assignee "" }}{{end}}{{if .meta.fields.reporter}}
+    emailAddress: {{ or .overrides.assignee "" }}
+{{end}}
+{{if .meta.fields.reporter}}
   reporter:
-    emailAddress: {{ or .overrides.reporter .overrides.login }}{{end}}{{if .meta.fields.customfield_10110}}
+    emailAddress: {{ or .overrides.reporter .overrides.login }}
+{{end}}
+{{if .meta.fields.customfield_10110}}
   # watchers
   customfield_10110: {{ range split "," (or .overrides.watchers "")}}
     - name: {{.}}{{end}}
-    - name:{{end}}
+    - name:
+{{end}}
   issuetype:
     name: Sub-task
   parent:

--- a/jiracli/templates.go
+++ b/jiracli/templates.go
@@ -422,9 +422,17 @@ fields:
   summary: >-
     {{ or .overrides.summary .fields.summary }}
 {{- if and .meta.fields.components .meta.fields.components.allowedValues }}
-  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{if .overrides.components }}{{ range (split "," .overrides.components)}}
-    - name: {{.}}{{end}}{{else}}{{ range .fields.components }}
-    - name: {{ .name }}{{end}}{{end}}{{end}}
+  components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}
+  {{if .overrides.components }}
+    {{ range (split "," .overrides.components)}}
+    - name: {{.}}
+    {{end}}
+  {{else}}
+    {{ range .fields.components }}
+    - name: {{ .name }}
+    {{end}}
+  {{end}}
+{{end}}
 {{- if .meta.fields.assignee }}
   {{- if .overrides.assignee }}
   assignee:
@@ -433,18 +441,27 @@ fields:
   assignee: {{if .fields.assignee.name}}
     emailAddress: {{ or .fields.assignee.name}}
   {{- else }}
-    emailAddress: {{.fields.assignee.emailAddress}}{{end}}{{end}}{{end}}
+    emailAddress: {{.fields.assignee.emailAddress}}
+  {{end}}{{end}}
+{{end}}
 {{- if .meta.fields.reporter}}
   reporter:
-    emailAddress: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.emailAddress }}{{end}}{{end}}
+    emailAddress: {{ if .overrides.reporter }}{{ .overrides.reporter }}{{else if .fields.reporter}}{{ .fields.reporter.emailAddress }}{{end}}
+{{end}}
 {{- if .meta.fields.customfield_10110}}
   # watchers
-  customfield_10110: {{ range .fields.customfield_10110 }}
-    - name: {{ .name }}{{end}}{{if .overrides.watcher}}
-    - name: {{ .overrides.watcher}}{{end}}{{end}}
+  customfield_10110:
+  {{ range .fields.customfield_10110 }}
+    - name: {{ .name }}
+  {{end}}
+  {{if .overrides.watcher}}
+    - name: {{ .overrides.watcher}}
+  {{end}}
+{{end}}
 {{- if .meta.fields.priority }}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
-    name: {{ or .overrides.priority .fields.priority.name "" }}{{end}}
+    name: {{ or .overrides.priority .fields.priority.name "" }}
+{{end}}
   description: |~
     {{ or .overrides.description .fields.description "" | indent 4 }}
 # votes: {{ .fields.votes.votes }}


### PR DESCRIPTION
The templates in jiracli/templates.go have logic in them. Currently, it's difficult to grok what's going on in these templates because of the way they're written.

This change does not introduce new functionality; it just sweeps through this template file ensuring that the templates are readable.

With this change, it would be easier — in future — to update these template, or introduce new functionality to these templates.

### Templates

- [x] AttachList
- [x] Comment
- [x] ComponentAdd
- [x] Components
- [x] Create
- [x] Debug
- [x] Edit
- [x] EpicCreate
- [x] Issuetypes
- [x] List
- [x] Subtask
- [x] Table
- [x] Transition
- [x] Transitions
- [x] View
- [x] Worklog
- [x] Worklogs
