### PR TITLE
fix createmeta issue on jira 9.x

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+* Jira 9.0 moved the parameters on api/2/issue/createmeta into path values
+  Need to allow both versions to function
+  Need a configuration item to indicate which url/method to call
+  Need to write the new method to conform to the new api method format


### PR DESCRIPTION
 * Jira changed the format of the call to createmeta

 * config.yml should default to old way
 * add a jira server version variable to config.yml to tell cli which method call to make