### PR TITLE
doc: Add go install command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Commands which previously took a username will now expect an email address such 
 
 ## Install
 
+If you have `go` installed already, you can run the following to install it directly:
+
+```
+go install github.com/go-jira/jira/cmd/jira@latest
+```
+
 ### Download
 
 You can download one of the pre-built binaries for **go-jira** [here](https://github.com/go-jira/jira/releases).


### PR DESCRIPTION
Fixes this warning:

```
$ go get -u github.com/go-jira/jira/cmd/jira
  go: go.mod file not found in current directory or any parent directory.
          'go get' is no longer supported outside a module.
          To build and install a command, use 'go install' with a version,
          like 'go install example.com/cmd@latest'
          For more information, see https://golang.org/doc/go-get-install-deprecation
          or run 'go help get' or 'go help install'.
```          